### PR TITLE
Add support for reusing source and destination fields

### DIFF
--- a/lib/beats_pipeline_generator.rb
+++ b/lib/beats_pipeline_generator.rb
@@ -6,10 +6,12 @@ def generate_beats_pipeline(mapping)
   fields_to_copy = []
   fields_to_rename = []
   fields_to_convert = []
-  mapping.each_pair do |source_field, row|
+  mapping.each_pair do |_, row|
     if same_field_name?(row)
       next if row[:format_action].nil?
     end
+
+    source_field = row[:source_field]
 
     if row[:destination_field]
       statement = {

--- a/lib/elasticsearch_pipeline_generator.rb
+++ b/lib/elasticsearch_pipeline_generator.rb
@@ -3,10 +3,12 @@ require_relative 'helpers'
 
 def generate_elasticsearch_pipeline(mapping)
   pipeline = []
-  mapping.each_pair do |source_field, row|
+  mapping.each_pair do |_, row|
     if same_field_name?(row)
       next if row[:format_action].nil?
     end
+
+    source_field = row[:source_field]
 
     # copy/rename
     if row[:destination_field]

--- a/lib/logstash_pipeline_generator.rb
+++ b/lib/logstash_pipeline_generator.rb
@@ -3,10 +3,13 @@ require_relative 'helpers'
 def generate_logstash_pipeline(mapping)
   mutations = [] # Most things are in the same mutate block
   array_fields = []
-  mapping.each_pair do |source_field, row|
+  mapping.each_pair do |_, row|
     if same_field_name?(row)
       next if row[:format_action].nil?
     end
+
+    source_field = row[:source_field]
+
     if row[:destination_field]
       if 'copy' == row[:rename]
         mutations << { 'copy' => { lsf(source_field) => lsf(row[:destination_field]) } }

--- a/lib/mapping_loader.rb
+++ b/lib/mapping_loader.rb
@@ -20,15 +20,15 @@ def csv_to_mapping(csv)
   mapping = {}
   csv.each do |row|
     # skip rows that don't have a source field
-    next if row['source_field'].nil? || row['source_field'].strip.empty?
+    next if row['source_field'].nil? || row['source_field'].strip.empty? || row['destination_field'].nil? || row['destination_field'].strip.empty?
 
     # Only read supported fields, ignore the rest
-    source_field = row['source_field']
-    dest_field = row['destination_field']
+    source_field = row['source_field'].strip
+    dest_field = row['destination_field'].strip
 
-    mapping[source_field + dest_field] = {
-      source_field:       row['source_field'],
-      destination_field:  (row['destination_field'] && row['destination_field'].strip),
+    mapping[source_field + '+' + dest_field] = {
+      source_field:       source_field,
+      destination_field:  dest_field,
       # optional fields
       rename:             (row['rename'] && row['rename'].strip),
       format_action:      (row['format_action'] && row['format_action'].strip),

--- a/lib/mapping_loader.rb
+++ b/lib/mapping_loader.rb
@@ -23,9 +23,11 @@ def csv_to_mapping(csv)
     next if row['source_field'].nil? || row['source_field'].strip.empty?
 
     # Only read supported fields, ignore the rest
-    source_field = row['source_field'].strip
-    mapping[source_field] = {
-      source_field:       source_field,
+    source_field = row['source_field']
+    dest_field = row['destination_field']
+
+    mapping[source_field + dest_field] = {
+      source_field:       row['source_field'],
       destination_field:  (row['destination_field'] && row['destination_field'].strip),
       # optional fields
       rename:             (row['rename'] && row['rename'].strip),

--- a/lib/mapping_loader.rb
+++ b/lib/mapping_loader.rb
@@ -20,7 +20,10 @@ def csv_to_mapping(csv)
   mapping = {}
   csv.each do |row|
     # skip rows that don't have a source field
-    next if row['source_field'].nil? || row['source_field'].strip.empty? || row['destination_field'].nil? || row['destination_field'].strip.empty?
+    next if row['source_field'].nil? ||
+            row['source_field'].strip.empty? ||
+            row['destination_field'].nil? ||
+            row['destination_field'].strip.empty?
 
     # Only read supported fields, ignore the rest
     source_field = row['source_field'].strip

--- a/test/unit/beats_pipeline_generator_test.rb
+++ b/test/unit/beats_pipeline_generator_test.rb
@@ -4,9 +4,9 @@ require_relative '../../lib/beats_pipeline_generator'
 class BeatsPipelineGeneratorTest < Minitest::Test
   def test_copy_and_rename_pipeline
     mapping = {
-      'old1' => { source_field: 'old1', destination_field: 'new1', rename: 'copy' },
-      'old2' => { source_field: 'old2', destination_field: 'new2', rename: 'rename' },
-      'old3' => { source_field: 'old3', destination_field: 'new3', rename: 'copy' },
+      'old1+new1' => { source_field: 'old1', destination_field: 'new1', rename: 'copy' },
+      'old2+new2' => { source_field: 'old2', destination_field: 'new2', rename: 'rename' },
+      'old3+new3' => { source_field: 'old3', destination_field: 'new3', rename: 'copy' },
     }
     pl = generate_beats_pipeline(mapping)
     copy_processor = pl[0]
@@ -29,11 +29,27 @@ class BeatsPipelineGeneratorTest < Minitest::Test
 
   def test_non_renamed_beats
     mapping = {
-      'field1' => { source_field: 'field1', destination_field: 'field1', rename: 'copy' },
-      'field2' => { source_field: 'field2', destination_field: nil, rename: 'copy' },
+      'field1+field1' => { source_field: 'field1', destination_field: 'field1', rename: 'copy' },
+      'field2+' => { source_field: 'field2', destination_field: nil, rename: 'copy' },
     }
     pl = generate_beats_pipeline(mapping)
     assert_equal([], pl, "No rename processor should be added when there's no rename to perform")
+  end
+
+  def test_duplicate_source_fields_same_destination
+    mapping = {
+      'field1+field3' => { source_field: 'field1', destination_field: 'field3', rename: 'copy' },
+      'field2+field3' => { source_field: 'field2', destination_field: 'field3', rename: 'copy' },
+      'field4+field5' => { source_field: 'field4', destination_field: 'field5', rename: 'copy' },
+      'field4+field6' => { source_field: 'field4', destination_field: 'field6', rename: 'copy' },
+    }
+
+    pl = generate_beats_pipeline(mapping)
+
+    assert_equal(
+      {"copy_fields"=>{"fields"=>[{"from"=>"field1", "to"=>"field3"}, {"from"=>"field2", "to"=>"field3"}, {"from"=>"field4", "to"=>"field5"}, {"from"=>"field4", "to"=>"field6"}], "ignore_missing"=>true, "fail_on_error"=>false}},
+      pl.first
+    )
   end
 
 end

--- a/test/unit/beats_pipeline_generator_test.rb
+++ b/test/unit/beats_pipeline_generator_test.rb
@@ -47,7 +47,14 @@ class BeatsPipelineGeneratorTest < Minitest::Test
     pl = generate_beats_pipeline(mapping)
 
     assert_equal(
-      {"copy_fields"=>{"fields"=>[{"from"=>"field1", "to"=>"field3"}, {"from"=>"field2", "to"=>"field3"}, {"from"=>"field4", "to"=>"field5"}, {"from"=>"field4", "to"=>"field6"}], "ignore_missing"=>true, "fail_on_error"=>false}},
+      { "copy_fields" => {
+          "fields" => [ 
+              {"from"=>"field1", "to"=>"field3"}, 
+              {"from"=>"field2", "to"=>"field3"}, 
+              {"from"=>"field4", "to"=>"field5"}, 
+              {"from"=>"field4", "to"=>"field6"}], 
+          "ignore_missing"=>true, 
+          "fail_on_error"=>false}},
       pl.first
     )
   end

--- a/test/unit/elasticsearch_pipeline_generator_test.rb
+++ b/test/unit/elasticsearch_pipeline_generator_test.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/elasticsearch_pipeline_generator'
 
 class OptionsParserTest < Minitest::Test
   def test_copy_processor
-    mapping = { 'old_field' => {
+    mapping = { 'old_field+new_field' => {
       source_field: 'old_field', destination_field: 'new_field', rename: 'copy'
     } }
     pl = generate_elasticsearch_pipeline(mapping)
@@ -15,7 +15,7 @@ class OptionsParserTest < Minitest::Test
   end
 
   def test_rename_processor
-    mapping = { 'old_field' => {
+    mapping = { 'old_field+new_field' => {
       source_field: 'old_field', destination_field: 'new_field', rename: 'rename'
     } }
     pl = generate_elasticsearch_pipeline(mapping)
@@ -28,8 +28,8 @@ class OptionsParserTest < Minitest::Test
 
   def test_non_renamed_elasticsearch
     mapping = {
-      'field1' => { source_field: 'field1', destination_field: 'field1', rename: 'copy' },
-      'field2' => { source_field: 'field2', destination_field: nil, rename: 'copy' },
+      'field1+field1' => { source_field: 'field1', destination_field: 'field1', rename: 'copy' },
+      'field2+' => { source_field: 'field2', destination_field: nil, rename: 'copy' },
     }
     pl = generate_elasticsearch_pipeline(mapping)
     assert_equal([], pl, "No rename processor should be added when there's no rename to perform")
@@ -47,13 +47,30 @@ class OptionsParserTest < Minitest::Test
 
   def test_duplicate_source_fields_same_destination
     mapping = {
-      'field1' => { source_field: 'field1', destination_field: 'field2', rename: 'copy' },
-      'field2' => { source_field: 'field2', destination_field: 'field2', rename: 'copy' },
+      'field1+field3' => { source_field: 'field1', destination_field: 'field3', rename: 'copy' },
+      'field2+field3' => { source_field: 'field2', destination_field: 'field3', rename: 'copy' },
+      'field4+field5' => { source_field: 'field4', destination_field: 'field5', rename: 'copy' },
+      'field4+field6' => { source_field: 'field4', destination_field: 'field6', rename: 'copy' },
     } 
 
-    p = generate_elasticsearch_pipeline(mapping)
-    puts p.inspect
- 
-  end
+    pl = generate_elasticsearch_pipeline(mapping)
 
+    assert_equal(4, pl.length, "Expected 4 processors")   
+    assert_equal(
+      {:set=>{:field=>"field3", :value=>"{{field1}}", :if=>"ctx.field1 != null"}},
+      pl[0]
+    )
+    assert_equal(
+      {:set=>{:field=>"field3", :value=>"{{field2}}", :if=>"ctx.field2 != null"}},
+      pl[1]
+    ) 
+    assert_equal(
+      {:set=>{:field=>"field5", :value=>"{{field4}}", :if=>"ctx.field4 != null"}},
+      pl[2]
+    )
+    assert_equal(
+      {:set=>{:field=>"field6", :value=>"{{field4}}", :if=>"ctx.field4 != null"}},
+      pl[3]
+    )         
+  end
 end

--- a/test/unit/elasticsearch_pipeline_generator_test.rb
+++ b/test/unit/elasticsearch_pipeline_generator_test.rb
@@ -44,4 +44,16 @@ class OptionsParserTest < Minitest::Test
     assert_equal("ctx.containsKey('@timestamp')",
                  field_presence_predicate('@timestamp'))
   end
+
+  def test_duplicate_source_fields_same_destination
+    mapping = {
+      'field1' => { source_field: 'field1', destination_field: 'field2', rename: 'copy' },
+      'field2' => { source_field: 'field2', destination_field: 'field2', rename: 'copy' },
+    } 
+
+    p = generate_elasticsearch_pipeline(mapping)
+    puts p.inspect
+ 
+  end
+
 end

--- a/test/unit/logstash_pipeline_generator_test.rb
+++ b/test/unit/logstash_pipeline_generator_test.rb
@@ -49,4 +49,20 @@ class LogstashPipelineGeneratorTest < Minitest::Test
       render_mutate_line('uppercase' => ['[log][level]'])
     )
   end
+
+  def test_duplicate_source_fields_same_destination
+    mapping = {
+      'field1+field3' => { source_field: 'field1', destination_field: 'field3', rename: 'copy' },
+      'field2+field3' => { source_field: 'field2', destination_field: 'field3', rename: 'copy' },
+      'field4+field5' => { source_field: 'field4', destination_field: 'field5', rename: 'copy' },
+      'field4+field6' => { source_field: 'field4', destination_field: 'field6', rename: 'copy' },
+    }
+
+    pl = generate_logstash_pipeline(mapping)
+
+    assert_equal(
+      [{"copy"=>{"[field1]"=>"[field3]"}}, {"copy"=>{"[field2]"=>"[field3]"}}, {"copy"=>{"[field4]"=>"[field5]"}}, {"copy"=>{"[field4]"=>"[field6]"}}],
+      pl.first
+    )
+  end
 end

--- a/test/unit/mapping_loader_test.rb
+++ b/test/unit/mapping_loader_test.rb
@@ -33,7 +33,7 @@ class MappingLoaderTest < Minitest::Test
              'rename' => ' copy',
     }]
     expected_mapping = {
-      'my_field' => {
+      'my_field+another_field' => {
         source_field: 'my_field',
         destination_field: 'another_field',
         rename: 'copy',
@@ -52,25 +52,19 @@ class MappingLoaderTest < Minitest::Test
     validate_mapping!({ 'foo' => {:format_action => 'to_array'}})
   end
 
-  def test_mapping_loader_skips_missing_source_field
+  def test_mapping_loader_skips_missing_fields
     csv = [
       # skipped
       { 'source_field' => nil,           'destination_field' => nil },
       { 'source_field' => nil,           'destination_field' => 'fieldname' },
       { 'source_field' => ' ',           'destination_field' => '  ' },
-      { 'source_field' => "\t",           'destination_field' => 'fieldname' },
-      # Not skipped
+      { 'source_field' => "\t",          'destination_field' => 'fieldname' },
       { 'source_field' => 'correct_fieldname',  'destination_field' => nil },
+      # Not skipped
       { 'source_field' => 'original_fieldname', 'destination_field' => 'new_fieldname' },
     ]
     expected_mapping = {
-      'correct_fieldname' => {
-        source_field: 'correct_fieldname',
-        destination_field: nil,
-        rename: nil,
-        format_action: nil,
-      },
-      'original_fieldname' => {
+      'original_fieldname+new_fieldname' => {
         source_field: 'original_fieldname',
         destination_field: 'new_fieldname',
         rename: nil,


### PR DESCRIPTION
This PR resolves https://github.com/elastic/ecs-mapper/issues/1. 

It addresses two issues.

1. Mapping multiple source fields to the same destination field for different event types
2. Mapping the same source field to multiple destination fields for the same event type

## Proof it works

```
$ cat ~/Downloads/reuse-bug.csv 
source_field,destination_field
the_same_field,event.action
the_same_field,message
some_new_field,message

$ ./ecs-mapper -f ~/Downloads/reuse.csv --rename-action copy
/Users/tony/Downloads/elasticsearch.json
/Users/tony/Downloads/beats.yml
/Users/tony/Downloads/logstash.conf

$ cat /Users/tony/Downloads/elasticsearch.json
[
  {
    "set": {
      "field": "event.action",
      "value": "{{the_same_field}}",
      "if": "ctx.the_same_field != null"
    }
  },
  {
    "set": {
      "field": "message",
      "value": "{{the_same_field}}",
      "if": "ctx.the_same_field != null"
    }
  },
  {
    "set": {
      "field": "message",
      "value": "{{some_new_field}}",
      "if": "ctx.some_new_field != null"
    }
  }
]

$ cat /Users/tony/Downloads/beats.yml
processors:
- copy_fields:
    fields:
    - from: the_same_field
      to: event.action
    - from: the_same_field
      to: message
    - from: some_new_field
      to: message
    ignore_missing: true
    fail_on_error: false

$ cat /Users/tony/Downloads/logstash.conf
filter {
  mutate {
    copy => { '[the_same_field]' => '[event][action]' }
    copy => { '[the_same_field]' => '[message]' }
    copy => { '[some_new_field]' => '[message]' }
  }
}

$ rake test
/Users/tony/Code/git/ecs-mapper/test/unit/logstash_pipeline_generator_test.rb:11: warning: assigned but unused variable - array_fields
/Users/tony/Code/git/ecs-mapper/test/unit/logstash_pipeline_generator_test.rb:25: warning: assigned but unused variable - array_fields
Run options: --seed 6403

# Running:

......................

Finished in 0.003373s, 6522.3839 runs/s, 11265.9359 assertions/s.

22 runs, 38 assertions, 0 failures, 0 errors, 0 skips
```