### PR TITLE
Remove `file` input from logstash example config

### DIFF
--- a/example/logstash/1-input.conf
+++ b/example/logstash/1-input.conf
@@ -1,9 +1,5 @@
 input {
   stdin { codec => json_lines }
-  file {
-    codec => json_lines
-    path => 'example/log-sample.log'
-  }
 }
 
 filter {


### PR DESCRIPTION
Encountered this minor issue when running through the `example` steps:

The `path` setting for the `file` input plugin needs an [absolute path](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-file.html#plugins-inputs-file-path). With the current input `file` config using a relative path, this causes an exception when trying to run Logstash following the steps in `example/README.md`.

The current Logstash example relies on using `stdin`, so I'm proposing removing `file` entirely.